### PR TITLE
Validate current password

### DIFF
--- a/src/Pages/Profile.php
+++ b/src/Pages/Profile.php
@@ -84,7 +84,7 @@ class Profile extends Page implements HasForms
                     TextInput::make('current_password')
                         ->label('Current Password')
                         ->password()
-                        ->rules(['required_with:new_password'])
+                        ->rules(['required_with:new_password', 'password'])
                         ->currentPassword()
                         ->autocomplete('off')
                         ->columnSpan(1),


### PR DESCRIPTION
Shouldn't current password be validated, if it is filled?
If so, this PR adds `password` validation rule to current_password.